### PR TITLE
Bump build dependencies for JupyterLite 0.7.0

### DIFF
--- a/.github/build-environment.yml
+++ b/.github/build-environment.yml
@@ -5,6 +5,6 @@ dependencies:
   - python
   - pip
   - jupyter_server
-  - jupyterlite-core >=0.6
-  - jupyterlite-xeus >=4
-  - notebook >=7.4
+  - jupyterlite-core >=0.7
+  - jupyterlite-xeus >=4.3
+  - notebook >=7.5


### PR DESCRIPTION
To align on the latest stable releases.